### PR TITLE
Feat : 회원 인증 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     // Database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     // QueryDSL (JPA + Annotation Processor)
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,21 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    // Security & JWT
+    implementation 'io.jsonwebtoken:jjwt:0.11.5'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Email Support
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    // valid
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
+
 
 def querydslDir = "src/main/generated"
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,15 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // TSID
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.4'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // valid
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 def querydslDir = "src/main/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 

--- a/src/main/java/sns/pinocchio/application/base/errorResponse/ErrorResponse.java
+++ b/src/main/java/sns/pinocchio/application/base/errorResponse/ErrorResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import java.util.HashMap;
 import java.util.Map;
 
-// 구조화된 에러 응답 DTO
+// 에러 응답 DTO
 @Getter
 @AllArgsConstructor
 public class ErrorResponse {

--- a/src/main/java/sns/pinocchio/application/base/errorResponse/ErrorResponse.java
+++ b/src/main/java/sns/pinocchio/application/base/errorResponse/ErrorResponse.java
@@ -1,0 +1,23 @@
+package sns.pinocchio.application.base.errorResponse;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// 구조화된 에러 응답 DTO
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private Map<String, String> details;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.details = new HashMap<>();
+    }
+}

--- a/src/main/java/sns/pinocchio/application/blockedUser/BlockedUserService.java
+++ b/src/main/java/sns/pinocchio/application/blockedUser/BlockedUserService.java
@@ -1,0 +1,13 @@
+package sns.pinocchio.application.blockedUser;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sns.pinocchio.infrastructure.blockedUser.BlockedUserRepository;
+
+@RequiredArgsConstructor
+@Service
+public class BlockedUserService {
+
+    private final BlockedUserRepository blockedUserRepository;
+
+}

--- a/src/main/java/sns/pinocchio/application/loginHistory/LoginHistoryService.java
+++ b/src/main/java/sns/pinocchio/application/loginHistory/LoginHistoryService.java
@@ -1,0 +1,7 @@
+package sns.pinocchio.application.loginHistory;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginHistoryService {
+}

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -1,15 +1,19 @@
 package sns.pinocchio.application.member;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import sns.pinocchio.application.member.memberDto.MemberInfoDto;
 import sns.pinocchio.application.member.memberDto.MemberRequestDto;
 import sns.pinocchio.config.global.auth.service.CookieService;
+import sns.pinocchio.config.global.auth.util.JwtUtil;
 import sns.pinocchio.config.global.auth.util.TokenProvider;
 import sns.pinocchio.domain.member.Member;
 import sns.pinocchio.infrastructure.member.MemberRepository;
+import sns.pinocchio.infrastructure.persistence.redis.redisService.RedisService;
 import sns.pinocchio.presentation.member.exception.MemberErrorCode;
 import sns.pinocchio.presentation.member.exception.MemberException;
 
@@ -20,7 +24,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final CookieService cookieService;
+    private final RedisService redisService;
     private final TokenProvider tokenProvider;
+    private final JwtUtil jwtUtil;
 
     // 계정 생성
     @Transactional
@@ -43,7 +49,7 @@ public class MemberService {
 
     // 이메일 검증
     public void validateEmail(String email) {
-        if(this.memberRepository.existsByEmail(email)) {
+        if(memberRepository.existsByEmail(email)) {
             return;
         }
         throw new MemberException(MemberErrorCode.EMAIL_NOT_FOUND);
@@ -51,7 +57,7 @@ public class MemberService {
 
     // 패스워드 검증
     public void validatePassword(String password, String email) {
-        Member member = this.memberRepository.findByEmail(email);
+        Member member = memberRepository.findByEmail(email);
 
         if(passwordEncoder.matches(password, member.getPassword())) {
             return;
@@ -61,20 +67,27 @@ public class MemberService {
 
     // 엑세스토큰 생성 및 저장
     public void generateToken(String email, HttpServletResponse response) {
-        Member member = this.memberRepository.findByEmail(email);
-        String accessToken = this.tokenProvider.generateAccessToken(member);
+        Member member = memberRepository.findByEmail(email);
+        String accessToken = tokenProvider.generateAccessToken(member);
         this.cookieService.addAccessTokenToCookie(accessToken, response);
     }
 
     // 리프래시토큰 생성 및 저장
-    public void generateAndSaveRefreshToken(HttpServletResponse response) {
-        String refreshToken = this.tokenProvider.generateRefreshToken();
+    public void generateAndSaveRefreshToken(String email, HttpServletResponse response) {
+        Member member = memberRepository.findByEmail(email);
+        String refreshToken = tokenProvider.generateRefreshToken();
+
+        this.redisService.save(refreshToken, String.valueOf(member.getId()), jwtUtil.getRefreshTokenExpirationTime());
         this.cookieService.addRefreshTokenToCookie(refreshToken, response);
 
     }
 
     // 토큰 제거
-    public void logout(HttpServletResponse response) {
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = this.cookieService.getAccessTokenFromCookie(request);
+        MemberInfoDto member = this.jwtUtil.getMemberInfoDto(accessToken);
+
+        this.redisService.addBlackList(String.valueOf(member.id()), this.jwtUtil.getRefreshTokenExpirationTime());
         this.cookieService.clearTokenFromCookie(response);
     }
 

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -17,7 +17,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // 유저 생성
+    // 계정 생성
     @Transactional
     public void createMember(MemberRequestDto memberRequestDto) {
 
@@ -34,5 +34,23 @@ public class MemberService {
                 .build();
 
         this.memberRepository.save(member);
+    }
+
+    // 이메일 검증
+    public void validateEmail(String email) {
+        if(this.memberRepository.existsByEmail(email)) {
+            return;
+        }
+        throw new MemberException(MemberErrorCode.EMAIL_NOT_FOUND);
+    }
+
+    // 패스워드 검증
+    public void validatePassword(String password, String email) {
+        Member member = this.memberRepository.findByEmail(email);
+
+        if(passwordEncoder.matches(password, member.getPassword())) {
+            return;
+        }
+        throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
     }
 }

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -1,0 +1,7 @@
+package sns.pinocchio.application.member;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+}

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -1,10 +1,13 @@
 package sns.pinocchio.application.member;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import sns.pinocchio.application.member.memberDto.MemberRequestDto;
+import sns.pinocchio.config.global.auth.service.CookieService;
+import sns.pinocchio.config.global.auth.util.TokenProvider;
 import sns.pinocchio.domain.member.Member;
 import sns.pinocchio.infrastructure.member.MemberRepository;
 import sns.pinocchio.presentation.member.exception.MemberErrorCode;
@@ -16,21 +19,23 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final CookieService cookieService;
+    private final TokenProvider tokenProvider;
 
     // 계정 생성
     @Transactional
     public void createMember(MemberRequestDto memberRequestDto) {
 
         // 이메일 중복 체크
-        if (memberRepository.existsByEmail(memberRequestDto.getEmail())) {
+        if (memberRepository.existsByEmail(memberRequestDto.email())) {
             throw new MemberException(MemberErrorCode.EMAIL_DUPLICATED);
         }
 
         Member member = Member.builder()
-                .email(memberRequestDto.getEmail())
-                .name(memberRequestDto.getName())
-                .nickname(memberRequestDto.getNickname())
-                .password(passwordEncoder.encode(memberRequestDto.getPassword()))
+                .email(memberRequestDto.email())
+                .name(memberRequestDto.name())
+                .nickname(memberRequestDto.nickname())
+                .password(passwordEncoder.encode(memberRequestDto.password()))
                 .build();
 
         this.memberRepository.save(member);
@@ -52,5 +57,28 @@ public class MemberService {
             return;
         }
         throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
+    }
+
+    // 엑세스토큰 생성 및 저장
+    public void generateToken(String email, HttpServletResponse response) {
+        Member member = this.memberRepository.findByEmail(email);
+        String accessToken = this.tokenProvider.generateAccessToken(member);
+        this.cookieService.addAccessTokenToCookie(accessToken, response);
+    }
+
+    // 리프래시토큰 생성 및 저장
+    public void generateAndSaveRefreshToken(HttpServletResponse response) {
+        String refreshToken = this.tokenProvider.generateRefreshToken();
+        this.cookieService.addRefreshTokenToCookie(refreshToken, response);
+
+    }
+
+    // 토큰 제거
+    public void logout(HttpServletResponse response) {
+        this.cookieService.clearTokenFromCookie(response);
+    }
+
+    public Member findByUsername(String username) {
+        return this.memberRepository.findByName(username);
     }
 }

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -94,4 +94,9 @@ public class MemberService {
     public Member findByUsername(String username) {
         return this.memberRepository.findByName(username);
     }
+
+    public Member findByUserId(Long memberId) {
+        return this.memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/sns/pinocchio/application/member/MemberService.java
+++ b/src/main/java/sns/pinocchio/application/member/MemberService.java
@@ -1,7 +1,38 @@
 package sns.pinocchio.application.member;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import sns.pinocchio.application.member.memberDto.MemberRequestDto;
+import sns.pinocchio.domain.member.Member;
+import sns.pinocchio.infrastructure.member.MemberRepository;
+import sns.pinocchio.presentation.member.exception.MemberErrorCode;
+import sns.pinocchio.presentation.member.exception.MemberException;
 
+@RequiredArgsConstructor
 @Service
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 유저 생성
+    @Transactional
+    public void createMember(MemberRequestDto memberRequestDto) {
+
+        // 이메일 중복 체크
+        if (memberRepository.existsByEmail(memberRequestDto.getEmail())) {
+            throw new MemberException(MemberErrorCode.EMAIL_DUPLICATED);
+        }
+
+        Member member = Member.builder()
+                .email(memberRequestDto.getEmail())
+                .name(memberRequestDto.getName())
+                .nickname(memberRequestDto.getNickname())
+                .password(passwordEncoder.encode(memberRequestDto.getPassword()))
+                .build();
+
+        this.memberRepository.save(member);
+    }
 }

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberInfoDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberInfoDto.java
@@ -1,0 +1,21 @@
+package sns.pinocchio.application.member.memberDto;
+
+import lombok.Builder;
+import sns.pinocchio.domain.member.Member;
+
+// 사용자 기본 정보만 담는 dto
+@Builder
+public record MemberInfoDto(
+        Long id,
+        String nickname,
+        String email
+) {
+
+    public static MemberInfoDto of(Member member) {
+        return MemberInfoDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberInfoDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberInfoDto.java
@@ -6,7 +6,7 @@ import sns.pinocchio.domain.member.Member;
 // 사용자 기본 정보만 담는 dto
 @Builder
 public record MemberInfoDto(
-        Long id,
+        String id,
         String nickname,
         String email
 ) {

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberLoginRequestDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberLoginRequestDto.java
@@ -2,16 +2,14 @@ package sns.pinocchio.application.member.memberDto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 
 
-@Getter
-public class MemberLoginRequestDto {
+public record MemberLoginRequestDto(
+        @NotBlank(message = "이메일은 필수 항목입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
 
-    @NotBlank(message = "이메일은 필수 항목입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
-
-    @NotBlank(message = "비밀번호는 필수 항목입니다.")
-    private String password;
+        @NotBlank(message = "비밀번호는 필수 항목입니다.")
+        String password
+) {
 }

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberLoginRequestDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberLoginRequestDto.java
@@ -1,0 +1,17 @@
+package sns.pinocchio.application.member.memberDto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+
+@Getter
+public class MemberLoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    private String password;
+}

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
@@ -4,15 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class MemberRequestDto {
 
     @NotBlank(message = "이름은 필수 항목입니다.")

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
@@ -1,7 +1,8 @@
-package sns.pinocchio.presentation.member.memberDto;
+package sns.pinocchio.application.member.memberDto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,5 +28,6 @@ public class MemberRequestDto {
 
     @NotBlank(message = "비밀번호는 필수 항목입니다.")
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "비밀번호는 특수문자를 포함해야 합니다.")
     private String password;
 }

--- a/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
+++ b/src/main/java/sns/pinocchio/application/member/memberDto/MemberRequestDto.java
@@ -4,24 +4,22 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
 
-@Getter
-public class MemberRequestDto {
+public record MemberRequestDto(
+        @NotBlank(message = "이름은 필수 항목입니다.")
+        String name,
 
-    @NotBlank(message = "이름은 필수 항목입니다.")
-    private String name;
+        @NotBlank(message = "이메일은 필수 항목입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
 
-    @NotBlank(message = "이메일은 필수 항목입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
+        @NotBlank(message = "닉네임은 필수 항목입니다.")
+        @Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하로 입력해주세요.")
+        String nickname,
 
-    @NotBlank(message = "닉네임은 필수 항목입니다.")
-    @Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하로 입력해주세요.")
-    private String nickname;
-
-    @NotBlank(message = "비밀번호는 필수 항목입니다.")
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-    @Pattern(regexp = "^(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "비밀번호는 특수문자를 포함해야 합니다.")
-    private String password;
+        @NotBlank(message = "비밀번호는 필수 항목입니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "비밀번호는 특수문자를 포함해야 합니다.")
+        String password
+) {
 }

--- a/src/main/java/sns/pinocchio/application/report/ReportService.java
+++ b/src/main/java/sns/pinocchio/application/report/ReportService.java
@@ -1,0 +1,7 @@
+package sns.pinocchio.application.report;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportService {
+}

--- a/src/main/java/sns/pinocchio/config/global/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/sns/pinocchio/config/global/ExceptionHandler/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package sns.pinocchio.config.global.ExceptionHandler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import sns.pinocchio.application.base.errorResponse.ErrorResponse;
+import sns.pinocchio.presentation.member.exception.MemberException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<String> handleMemberException(MemberException ex) {
+        // 예외에 맞는 HTTP 상태 코드와 메시지 반환
+        return ResponseEntity
+                .status(ex.getStatus())  // 예외에서 정의한 HTTP 상태 코드 반환
+                .body(ex.getMessage());  // 예외에서 정의한 메시지 반환
+    }
+
+    // 다른 예외들도 일관된 형태로 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(
+                error -> errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "VALIDATION_ERROR",
+                "입력 값 검증 실패",
+                errors
+        );
+
+        return ResponseEntity
+                .badRequest()
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/exception/AuthErrorCode.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+// auth 관련 예외 코드
 @AllArgsConstructor
 @Getter
 public enum AuthErrorCode {

--- a/src/main/java/sns/pinocchio/config/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/exception/AuthErrorCode.java
@@ -1,0 +1,18 @@
+package sns.pinocchio.config.global.auth.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum AuthErrorCode {
+    AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "401-1", "인증에 실패했습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401-2", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "401-3", "유효하지 않은 토큰입니다."),
+    TOKEN_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500", "토큰 갱신에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/exception/AuthException.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/exception/AuthException.java
@@ -1,0 +1,20 @@
+package sns.pinocchio.config.global.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AuthException extends RuntimeException {
+    private final AuthErrorCode authErrorCode;
+
+    public AuthException(AuthErrorCode authErrorCode) {
+        super(authErrorCode.getMessage());
+        this.authErrorCode = authErrorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return authErrorCode.getHttpStatus();
+    }
+
+    public String getCode() {
+        return authErrorCode.getCode();
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/exception/AuthException.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/exception/AuthException.java
@@ -2,6 +2,7 @@ package sns.pinocchio.config.global.auth.exception;
 
 import org.springframework.http.HttpStatus;
 
+// auth 관련 예외 처리
 public class AuthException extends RuntimeException {
     private final AuthErrorCode authErrorCode;
 

--- a/src/main/java/sns/pinocchio/config/global/auth/jwt/MemberAuthFilter.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/jwt/MemberAuthFilter.java
@@ -1,0 +1,126 @@
+package sns.pinocchio.config.global.auth.jwt;
+
+import com.fasterxml.jackson.core.ObjectCodec;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import sns.pinocchio.config.global.auth.exception.AuthErrorCode;
+import sns.pinocchio.config.global.auth.exception.AuthException;
+import sns.pinocchio.config.global.auth.model.CustomUserDetails;
+import sns.pinocchio.config.global.auth.service.CookieService;
+import sns.pinocchio.config.global.auth.service.CustomUserDetailService;
+import sns.pinocchio.config.global.auth.util.JwtUtil;
+
+import java.io.IOException;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MemberAuthFilter extends OncePerRequestFilter {
+
+    private final CookieService cookieService;
+    private final CustomUserDetailService customUserDetailService;
+    private final JwtUtil jwtUtil;
+
+    ObjectCodec objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        final String accessToken = cookieService.getAccessTokenFromCookie(request);
+        final String refreshToken = cookieService.getRefreshTokenFromCookie(request);
+
+        // 엑세스 토큰과 리프레쉬 토큰이 null일 경우 에러 응답
+        // 엑세스 토큰만 null일 경우 리프레쉬 토큰으로 토큰 재발급 후 인증
+        if (accessToken == null) {
+            if (refreshToken == null) {
+                handleAuthError(AuthErrorCode.AUTHORIZATION_FAILED, request, response);
+                return;
+            }
+            String reissuedAccessToken = reissueToken(refreshToken, request, response);
+            setAuthenticationInContext(reissuedAccessToken);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            TokenStatus tokenStatus = jwtUtil.validateToken(accessToken);
+
+            switch (tokenStatus) {
+                case VALID:
+                    setAuthenticationInContext(accessToken);
+                    break;
+
+                case EXPIRED:
+                    log.info("만료된 토큰입니다.");
+                    String reissuedAccessToken = reissueToken(refreshToken, request, response);
+                    setAuthenticationInContext(reissuedAccessToken);
+                    break;
+
+                case MALFORMED, INVALID:
+                    log.error("잘못된 형식의 토큰입니다.");
+                    handleAuthError(AuthErrorCode.INVALID_TOKEN, request, response);
+                    return;
+            }
+        } catch (Exception e) {
+            log.error("필터 내부에서 예상치 못한 예외 발생: {}", e.getMessage());
+            handleAuthError(AuthErrorCode.AUTHORIZATION_FAILED, request, response);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // 사용자 권한이 필요한 api 경로만 필터링을 하는 메서드
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        return (
+                (method.equals("GET") && path.equals("/api/posts/search")) ||
+                (method.equals("POST") && path.equals("/api/auth/signup")) ||
+                (method.equals("POST") && path.equals("/api/auth/login")) ||
+                (method.equals("POST") && path.equals("/api/auth/logout"))
+        );
+    }
+
+    // SecurityContext에 인증 정보를 주입하는 메서드
+    private void setAuthenticationInContext(String accessToken) {
+        CustomUserDetails customUserDetails = customUserDetailService.loadUserByAccessToken(accessToken);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+
+    // 인증에 실패했을 때 로그아웃 처리 및 에러 응답 메서드
+    private void handleAuthError(AuthErrorCode ex,
+                                 HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        cookieService.clearTokenFromCookie(response);
+        SecurityContextHolder.clearContext();
+
+        throw new AuthException(ex);
+    }
+
+
+    // 토큰 재발급 및 쿠키에 토큰 정보 저장하는 메서드
+    private String reissueToken(String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+        // TODO : 엑세스토큰 재발급 로직
+        // 1. 리프레시토큰으로 레디스 내부 존재 여부 확인.
+        // 2. 토큰 유효시 저장된 유저 ID로 MemberRepository.findById()
+        // 3. 유저 객체로 엑세스토큰 생성 후 쿠키 저장.
+        return refreshToken;
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/jwt/TokenStatus.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/jwt/TokenStatus.java
@@ -1,0 +1,8 @@
+package sns.pinocchio.config.global.auth.jwt;
+
+public enum TokenStatus {
+    VALID,         // 유효한 토큰
+    EXPIRED,       // 만료된 토큰
+    MALFORMED,     // 잘못된 형식의 토큰
+    INVALID;       // 비어있거나 유효하지 않은 토큰
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/model/CustomUserDetails.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/model/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package sns.pinocchio.config.global.auth.model;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import sns.pinocchio.application.member.memberDto.MemberInfoDto;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    // 로그인한 사용자의 정보를 담는 DTO
+    private final MemberInfoDto memberInfoDto;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 사용자의 권한 설정
+        return List.of(new SimpleGrantedAuthority("USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // 비밀번호 반환 - 보안상 null 로 설정
+    }
+
+    @Override
+    public String getUsername() {
+        return memberInfoDto.nickname(); // 닉네임 반환
+    }
+
+    public Long getUserId() {
+        return memberInfoDto.id(); // 유저 ID 반환
+    }
+
+    public String getEmail() {
+        return memberInfoDto.email(); // 이메일 반환
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired(); // 계정 만료 여부 설정
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked(); // 계정 잠김 여부 설정
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired(); // 자격 증명(비밀번호) 만료 여부 설정
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled(); // 계정 활성화 여부 설정
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/model/CustomUserDetails.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/model/CustomUserDetails.java
@@ -31,7 +31,7 @@ public class CustomUserDetails implements UserDetails {
         return memberInfoDto.nickname(); // 닉네임 반환
     }
 
-    public Long getUserId() {
+    public String getUserId() {
         return memberInfoDto.id(); // 유저 ID 반환
     }
 

--- a/src/main/java/sns/pinocchio/config/global/auth/service/CookieService.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/service/CookieService.java
@@ -1,0 +1,44 @@
+package sns.pinocchio.config.global.auth.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sns.pinocchio.config.global.auth.util.CookieUtil;
+import sns.pinocchio.config.global.auth.util.JwtUtil;
+
+@Service
+@RequiredArgsConstructor
+public class CookieService {
+
+    private final CookieUtil cookieUtil;
+    private final JwtUtil jwtUtil;
+
+    // 엑세스토큰 저장
+    public void addAccessTokenToCookie(String accessToken, HttpServletResponse response) {
+        cookieUtil.addTokenToCookie("accessToken", accessToken,
+                jwtUtil.getAccessTokenExpirationTime(), response);
+    }
+
+    // 리프레시토큰 저장
+    public void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
+        cookieUtil.addTokenToCookie("refreshToken", refreshToken,
+                jwtUtil.getRefreshTokenExpirationTime(), response);
+    }
+
+    // 쿠키에서 엑세스토큰 추출
+    public String getAccessTokenFromCookie(HttpServletRequest request) {
+        return cookieUtil.getTokenFromCookie("accessToken", request);
+    }
+
+    // 쿠키에서 리프레시토큰 추출
+    public String getRefreshTokenFromCookie(HttpServletRequest request) {
+        return cookieUtil.getTokenFromCookie("refreshToken", request);
+    }
+
+    // 토큰 만료
+    public void clearTokenFromCookie(HttpServletResponse response) {
+        cookieUtil.addTokenToCookie("accessToken", null, 0, response);
+        cookieUtil.addTokenToCookie("refreshToken", null, 0, response);
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/service/CustomUserDetailService.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/service/CustomUserDetailService.java
@@ -19,9 +19,9 @@ public class CustomUserDetailService implements UserDetailsService {
     private final JwtUtil jwtUtil;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        Member member = memberService.findByUsername(username);
+        Member member = memberService.findByEmail(email);
         return new CustomUserDetails(MemberInfoDto.of(member));
     }
 

--- a/src/main/java/sns/pinocchio/config/global/auth/service/CustomUserDetailService.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/service/CustomUserDetailService.java
@@ -1,0 +1,32 @@
+package sns.pinocchio.config.global.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import sns.pinocchio.application.member.MemberService;
+import sns.pinocchio.application.member.memberDto.MemberInfoDto;
+import sns.pinocchio.config.global.auth.model.CustomUserDetails;
+import sns.pinocchio.config.global.auth.util.JwtUtil;
+import sns.pinocchio.domain.member.Member;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final MemberService memberService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberService.findByUsername(username);
+        return new CustomUserDetails(MemberInfoDto.of(member));
+    }
+
+    // UserDetails 생성
+    public CustomUserDetails loadUserByAccessToken(String accessToken) {
+        return new CustomUserDetails(jwtUtil.getMemberInfoDto(accessToken));
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/util/CookieUtil.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/util/CookieUtil.java
@@ -1,0 +1,38 @@
+package sns.pinocchio.config.global.auth.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class CookieUtil {
+
+    // 쿠키에 name 의 토큰을 저장하는 메서드
+    public void addTokenToCookie(String name, String value, long expiration, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(expiration)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    // 쿠키에서 name 의 토큰을 받아오는 메서드
+    public String getTokenFromCookie(String name, HttpServletRequest request) {
+        if (request.getCookies() == null)
+            return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/util/JwtUtil.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/util/JwtUtil.java
@@ -1,0 +1,84 @@
+package sns.pinocchio.config.global.auth.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import sns.pinocchio.application.member.memberDto.MemberInfoDto;
+import sns.pinocchio.config.global.auth.jwt.TokenStatus;
+
+import java.security.Key;
+
+@RequiredArgsConstructor
+@Component
+public class JwtUtil {
+
+    @Value("${spring.security.jwt.secret-key}")
+    private String SECRET_KEY;
+
+    @Value("${spring.security.jwt.access-token.expiration}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 6시간 (단위: ms)
+
+    @Value("${spring.security.jwt.refresh-token.expiration}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME; // 60일(약 2달) (단위: ms)
+
+    public Long getAccessTokenExpirationTime() {
+        return ACCESS_TOKEN_EXPIRATION_TIME;
+    }
+
+    public Long getRefreshTokenExpirationTime() {
+        return REFRESH_TOKEN_EXPIRATION_TIME;
+    }
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());  // `@Value` 주입된 후 실행됨
+    }
+
+    public Key getKey() {
+        return key;
+    }
+
+    // 토큰 검증 메서드
+    public TokenStatus validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return TokenStatus.VALID;               // 유효한 토큰
+        } catch (ExpiredJwtException e) {           // 토큰이 만료됨
+            return TokenStatus.EXPIRED;
+        } catch (MalformedJwtException e) {         //토큰이 올바르지 않음
+            return TokenStatus.MALFORMED;
+        } catch (IllegalArgumentException e) {      //토큰이 비었거나 올바르지 않음
+            return TokenStatus.INVALID;
+        }
+    }
+
+    // 토큰으로 유저 정보 가져오기
+    public MemberInfoDto getMemberInfoDto(String token) {
+        Claims claims = parseToken(token);
+        return MemberInfoDto.builder()
+                .id(claims.get("id", Long.class))
+                .nickname(claims.getSubject())
+                .email(claims.get("email", String.class))
+                .build();
+    }
+
+    // JWT 검증 및 정보 추출
+    public Claims parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/auth/util/JwtUtil.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/util/JwtUtil.java
@@ -67,7 +67,7 @@ public class JwtUtil {
     public MemberInfoDto getMemberInfoDto(String token) {
         Claims claims = parseToken(token);
         return MemberInfoDto.builder()
-                .id(claims.get("id", Long.class))
+                .id(claims.get("id", String.class))
                 .nickname(claims.getSubject())
                 .email(claims.get("email", String.class))
                 .build();

--- a/src/main/java/sns/pinocchio/config/global/auth/util/TokenProvider.java
+++ b/src/main/java/sns/pinocchio/config/global/auth/util/TokenProvider.java
@@ -1,0 +1,33 @@
+package sns.pinocchio.config.global.auth.util;
+
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import sns.pinocchio.domain.member.Member;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private final JwtUtil jwtUtil;
+
+    // JWT 토큰 생성
+    public String generateAccessToken(Member member) {
+        return Jwts.builder()
+                .setSubject(member.getName())  // 사용자 이름
+                .claim("id", member.getId())  // 사용자 ID
+                .claim("email", member.getEmail())  // 사용자 이메일
+                .setIssuedAt(new Date())  // 토큰 발급 시간
+                .setExpiration(new Date(System.currentTimeMillis() + jwtUtil.getAccessTokenExpirationTime()))  // 만료시간
+                .signWith(jwtUtil.getKey())  // 서명 알고리즘 및 키
+                .compact();
+    }
+
+    // 리프레시 토큰 생성
+    public String generateRefreshToken() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/sns/pinocchio/config/global/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/sns/pinocchio/config/global/exceptionHandler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package sns.pinocchio.config.global.ExceptionHandler;
+package sns.pinocchio.config.global.exceptionHandler;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
+++ b/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
@@ -17,12 +17,13 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Stateless로 세션 관리
-                .httpBasic(AbstractHttpConfigurer::disable) // 기본 HTTP 인증 비활성화
-                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
-                .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()  // 모든 요청 허용
+                        .anyRequest().permitAll() // 모든 요청 허용
                 );
         return http.build();
     }

--- a/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
+++ b/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
@@ -1,7 +1,9 @@
 package sns.pinocchio.config.securityConfig;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -9,10 +11,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sns.pinocchio.config.global.auth.jwt.MemberAuthFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Autowired
+    @Lazy
+    private MemberAuthFilter memberAuthFilter;
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -23,9 +31,9 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
                 .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**").permitAll()  // 로그인, 회원가입은 허용
-                        .anyRequest().authenticated()  // 나머지 요청은 인증 필요
+                        .anyRequest().permitAll()
                 )
+                .addFilterBefore(memberAuthFilter, UsernamePasswordAuthenticationFilter.class);
         ;
         return http.build();
     }

--- a/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
+++ b/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
@@ -18,13 +18,15 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 상태 없는 세션 정책 설정
+                .httpBasic(AbstractHttpConfigurer::disable) // 기본 HTTP 인증 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+                .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 모든 요청 허용
-                );
+                        .requestMatchers("/auth/**").permitAll()  // 로그인, 회원가입은 허용
+                        .anyRequest().authenticated()  // 나머지 요청은 인증 필요
+                )
+        ;
         return http.build();
     }
 

--- a/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
+++ b/src/main/java/sns/pinocchio/config/securityConfig/SecurityConfig.java
@@ -1,0 +1,35 @@
+package sns.pinocchio.config.securityConfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Stateless로 세션 관리
+                .httpBasic(AbstractHttpConfigurer::disable) // 기본 HTTP 인증 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+                .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()  // 모든 요청 허용
+                );
+        return http.build();
+    }
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/sns/pinocchio/domain/blockedUser/BlockedUser.java
+++ b/src/main/java/sns/pinocchio/domain/blockedUser/BlockedUser.java
@@ -1,0 +1,30 @@
+package sns.pinocchio.domain.blockedUser;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class BlockedUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private Long blockerUserId;
+
+    @Column(nullable = false)
+    private Long blockedUserId;
+
+    @Builder
+    public BlockedUser(Long blockerUserId, Long blockedUserId) {
+        this.blockerUserId = blockerUserId;
+        this.blockedUserId = blockedUserId;
+    }
+}

--- a/src/main/java/sns/pinocchio/domain/loginHistory/LoginHistory.java
+++ b/src/main/java/sns/pinocchio/domain/loginHistory/LoginHistory.java
@@ -1,0 +1,41 @@
+package sns.pinocchio.domain.loginHistory;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class LoginHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long loginHistoryId;
+
+    private Long userId;
+
+    private String loginIp;
+
+    private String loginDevice;
+
+    private String userAgent;
+
+    private LocalDateTime loginTime;
+
+    @Builder
+    public LoginHistory(Long userId, String loginIp, String loginDevice, String userAgent, LocalDateTime loginTime) {
+        this.userId = userId;
+        this.loginIp = loginIp;
+        this.loginDevice = loginDevice;
+        this.userAgent = userAgent;
+        this.loginTime = loginTime;
+    }
+}

--- a/src/main/java/sns/pinocchio/domain/member/Member.java
+++ b/src/main/java/sns/pinocchio/domain/member/Member.java
@@ -1,9 +1,45 @@
 package sns.pinocchio.domain.member;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    private String bio;
+
+    private String website;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String profileImageUrl;
+
+    private Boolean isActive;
+
+    @Builder
+    public Member(String password, String email, String name, String nickname) {
+        this.password = password;
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/sns/pinocchio/domain/member/Member.java
+++ b/src/main/java/sns/pinocchio/domain/member/Member.java
@@ -1,6 +1,9 @@
 package sns.pinocchio.domain.member;
 
-import jakarta.persistence.*;
+import com.github.f4b6a3.tsid.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,8 +15,7 @@ import lombok.NoArgsConstructor;
 public class Member {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private String id;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -36,10 +38,11 @@ public class Member {
     private Boolean isActive;
 
     @Builder
-    public Member(String password, String email, String name, String nickname) {
+    public Member(String password, String email, String name, String nickname, Tsid id) {
         this.password = password;
         this.email = email;
         this.name = name;
         this.nickname = nickname;
+        this.id = Tsid.fast().toString();
     }
 }

--- a/src/main/java/sns/pinocchio/domain/member/Member.java
+++ b/src/main/java/sns/pinocchio/domain/member/Member.java
@@ -1,6 +1,10 @@
 package sns.pinocchio.domain.member;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/sns/pinocchio/domain/member/Member.java
+++ b/src/main/java/sns/pinocchio/domain/member/Member.java
@@ -1,0 +1,9 @@
+package sns.pinocchio.domain.member;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+
+@Builder
+@Entity
+public class Member {
+}

--- a/src/main/java/sns/pinocchio/domain/report/Report.java
+++ b/src/main/java/sns/pinocchio/domain/report/Report.java
@@ -1,0 +1,47 @@
+package sns.pinocchio.domain.report;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+
+    private Long reporterId;
+
+    @Enumerated(EnumType.STRING)
+    private ReportedType reportedType;
+
+    private Long reportedId;
+
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    private ReportStatus status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Report(Long reporterId, ReportedType reportedType, Long reportedId, String reason, ReportStatus status, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.reporterId = reporterId;
+        this.reportedType = reportedType;
+        this.reportedId = reportedId;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}
+

--- a/src/main/java/sns/pinocchio/domain/report/ReportStatus.java
+++ b/src/main/java/sns/pinocchio/domain/report/ReportStatus.java
@@ -1,0 +1,5 @@
+package sns.pinocchio.domain.report;
+
+public enum ReportStatus {
+    PENDING, REVIEWED, RESOLVED
+}

--- a/src/main/java/sns/pinocchio/domain/report/ReportedType.java
+++ b/src/main/java/sns/pinocchio/domain/report/ReportedType.java
@@ -1,0 +1,5 @@
+package sns.pinocchio.domain.report;
+
+public enum ReportedType {
+    POST, COMMENT, USER
+}

--- a/src/main/java/sns/pinocchio/infrastructure/blockedUser/BlockedUserRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/blockedUser/BlockedUserRepository.java
@@ -1,0 +1,8 @@
+package sns.pinocchio.infrastructure.blockedUser;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlockedUserRepository extends JpaRepository<BlockedUserRepository, Integer> {
+}

--- a/src/main/java/sns/pinocchio/infrastructure/blockedUser/BlockedUserRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/blockedUser/BlockedUserRepository.java
@@ -2,7 +2,8 @@ package sns.pinocchio.infrastructure.blockedUser;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import sns.pinocchio.domain.blockedUser.BlockedUser;
 
 @Repository
-public interface BlockedUserRepository extends JpaRepository<BlockedUserRepository, Integer> {
+public interface BlockedUserRepository extends JpaRepository<BlockedUser, Integer> {
 }

--- a/src/main/java/sns/pinocchio/infrastructure/loginHistory/LoginHistoryRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/loginHistory/LoginHistoryRepository.java
@@ -1,0 +1,9 @@
+package sns.pinocchio.infrastructure.loginHistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sns.pinocchio.domain.loginHistory.LoginHistory;
+
+@Repository
+public interface LoginHistoryRepository extends JpaRepository<LoginHistory, Long> {
+}

--- a/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
@@ -7,4 +7,6 @@ import sns.pinocchio.domain.member.Member;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+
+    Member findByEmail(String email);
 }

--- a/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
@@ -6,4 +6,5 @@ import sns.pinocchio.domain.member.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
@@ -4,11 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import sns.pinocchio.domain.member.Member;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
-    Member findByEmail(String email);
+    Optional<Member> findByEmail(String email);
 
-    Member findByName(String username);
+    Optional<Member> findByName(String username);
 }

--- a/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
@@ -1,4 +1,4 @@
-package sns.pinocchio.infrastructure.persistence;
+package sns.pinocchio.infrastructure.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/member/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Member findByEmail(String email);
+
+    Member findByName(String username);
 }

--- a/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
@@ -1,7 +1,0 @@
-package sns.pinocchio.infrastructure.persistence;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MemberRepository {
-}

--- a/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
@@ -1,0 +1,7 @@
+package sns.pinocchio.infrastructure.persistence;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository {
+}

--- a/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/persistence/MemberRepository.java
@@ -1,7 +1,9 @@
 package sns.pinocchio.infrastructure.persistence;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import sns.pinocchio.domain.member.Member;
 
 @Repository
-public interface MemberRepository {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/sns/pinocchio/infrastructure/persistence/redis/redisDao/RedisDao.java
+++ b/src/main/java/sns/pinocchio/infrastructure/persistence/redis/redisDao/RedisDao.java
@@ -1,0 +1,46 @@
+package sns.pinocchio.infrastructure.persistence.redis.redisDao;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class RedisDao {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisDao(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 데이터 저장 (만료 시간 설정 없이)
+    public void save(String key, String value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    // 데이터 저장 (만료 시간 설정 포함)
+    public void save(String key, String value, long expirationTime) {
+        redisTemplate.opsForValue().set(key, value, expirationTime, TimeUnit.SECONDS);
+    }
+
+    // 데이터 조회
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // 데이터 존재 여부 확인
+    public boolean exists(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    // 데이터 삭제
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    // 만료 시간 갱신 (시간 단위는 초)
+    public void setExpiration(String key, long expirationTimeInSeconds) {
+        redisTemplate.expire(key, expirationTimeInSeconds, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/sns/pinocchio/infrastructure/persistence/redis/redisService/RedisService.java
+++ b/src/main/java/sns/pinocchio/infrastructure/persistence/redis/redisService/RedisService.java
@@ -1,0 +1,52 @@
+package sns.pinocchio.infrastructure.persistence.redis.redisService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sns.pinocchio.infrastructure.persistence.redis.redisDao.RedisDao;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisDao redisDao;
+
+    // 데이터 저장 (만료 시간 미설정)
+    public void save(String key, String value) {
+        redisDao.save(key, value);
+    }
+
+    // 데이터 저장 (만료 시간 설정)
+    public void save(String key, String value, long expirationTime) {
+        redisDao.save(key, value, expirationTime);
+    }
+
+    // 데이터 조회
+    public String get(String key) {
+        return redisDao.get(key);
+    }
+
+    // 키 존재 여부 확인
+    public boolean exists(String key) {
+        return redisDao.exists(key);
+    }
+
+    // 데이터 삭제
+    public void delete(String key) {
+        redisDao.delete(key);
+    }
+
+    // 만료 시간 설정
+    public void setExpiration(String key, long expirationTimeInSeconds) {
+        redisDao.setExpiration(key, expirationTimeInSeconds);
+    }
+
+    // 블랙리스트에 추가
+    public void addBlackList(String refreshToken, long expirationTimeInSeconds) {
+        redisDao.save(refreshToken, "blacklisted", expirationTimeInSeconds);
+    }
+
+    // 리프레시 토큰 유효성 체크
+    public boolean isValidRefreshToken(String key) {
+        return !"blacklisted".equals(redisDao.get(key));
+    }
+}

--- a/src/main/java/sns/pinocchio/infrastructure/report/ReportRepository.java
+++ b/src/main/java/sns/pinocchio/infrastructure/report/ReportRepository.java
@@ -1,0 +1,9 @@
+package sns.pinocchio.infrastructure.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sns.pinocchio.domain.report.Report;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -1,11 +1,15 @@
 package sns.pinocchio.presentation.auth;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sns.pinocchio.application.member.MemberService;
+import sns.pinocchio.application.member.memberDto.MemberRequestDto;
 
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -16,10 +20,15 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<String> signup() {
+    public ResponseEntity<String> signup(@RequestBody @Valid MemberRequestDto memberRequestDto) {
 
-        return ResponseEntity.ok("회원가입 성공");
+        memberService.createMember(memberRequestDto);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body("회원가입이 완료되었습니다.");
     }
+
 
     // 로그인
     @PostMapping("/login")

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -14,7 +14,7 @@ import sns.pinocchio.application.member.MemberService;
 import sns.pinocchio.application.member.memberDto.MemberLoginRequestDto;
 import sns.pinocchio.application.member.memberDto.MemberRequestDto;
 
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @RestController
 public class AuthController {
@@ -35,27 +35,22 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody @Valid MemberLoginRequestDto memberLoginRequestDto, HttpServletResponse response) {
-
-        String email = memberLoginRequestDto.email();
-        String password = memberLoginRequestDto.password();
-
+    public ResponseEntity<String> login(@RequestBody @Valid MemberLoginRequestDto loginRequestDto, HttpServletResponse response) {
         // 이메일 검증
-        memberService.validateEmail(email);
+        memberService.validateEmail(loginRequestDto.email());
         // 패스워드 검증
-        memberService.validatePassword(password, email);
+        memberService.validatePassword(loginRequestDto.password(), loginRequestDto.email());
 
         // 토콘 생성 및 저장
-        memberService.generateToken(email, response);
-        memberService.generateAndSaveRefreshToken(email, response);
+        memberService.generateAndSaveToken(loginRequestDto.email(), response);
 
-        return ResponseEntity.ok("로그인 성공");
+        return ResponseEntity.ok("로그인이 완료되었습니다.");
     }
 
     // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
         memberService.logout(request, response);
-        return ResponseEntity.ok("로그아웃 성공");
+        return ResponseEntity.ok("로그아웃 되었습니다.");
     }
 }

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -1,0 +1,37 @@
+package sns.pinocchio.presentation.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sns.pinocchio.application.member.MemberService;
+
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final MemberService memberService;
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup() {
+
+        return ResponseEntity.ok("회원가입 성공");
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<String> login() {
+
+        return ResponseEntity.ok("로그인 성공");
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout() {
+
+        return ResponseEntity.ok("로그아웃 성공");
+    }
+}

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -1,5 +1,6 @@
 package sns.pinocchio.presentation.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,16 +46,16 @@ public class AuthController {
         memberService.validatePassword(password, email);
 
         // 토콘 생성 및 저장
-        this.memberService.generateToken(email, response);
-        this.memberService.generateAndSaveRefreshToken(response);
+        memberService.generateToken(email, response);
+        memberService.generateAndSaveRefreshToken(email, response);
 
         return ResponseEntity.ok("로그인 성공");
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletResponse response) {
-        this.memberService.logout(response);
+    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+        memberService.logout(request, response);
         return ResponseEntity.ok("로그아웃 성공");
     }
 }

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sns.pinocchio.application.member.MemberService;
+import sns.pinocchio.application.member.memberDto.MemberLoginRequestDto;
 import sns.pinocchio.application.member.memberDto.MemberRequestDto;
 
 @RequestMapping("/auth")
@@ -21,7 +22,7 @@ public class AuthController {
     // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody @Valid MemberRequestDto memberRequestDto) {
-
+        // 계정 생성
         memberService.createMember(memberRequestDto);
 
         return ResponseEntity
@@ -32,7 +33,11 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<String> login() {
+    public ResponseEntity<String> login(@RequestBody @Valid MemberLoginRequestDto memberLoginRequestDto) {
+        // 이메일 검증
+        memberService.validateEmail(memberLoginRequestDto.getEmail());
+        // 패스워드 검증
+        memberService.validatePassword(memberLoginRequestDto.getPassword(), memberLoginRequestDto.getEmail());
 
         return ResponseEntity.ok("로그인 성공");
     }

--- a/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
+++ b/src/main/java/sns/pinocchio/presentation/auth/AuthController.java
@@ -1,5 +1,6 @@
 package sns.pinocchio.presentation.auth;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,19 +34,27 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody @Valid MemberLoginRequestDto memberLoginRequestDto) {
+    public ResponseEntity<String> login(@RequestBody @Valid MemberLoginRequestDto memberLoginRequestDto, HttpServletResponse response) {
+
+        String email = memberLoginRequestDto.email();
+        String password = memberLoginRequestDto.password();
+
         // 이메일 검증
-        memberService.validateEmail(memberLoginRequestDto.getEmail());
+        memberService.validateEmail(email);
         // 패스워드 검증
-        memberService.validatePassword(memberLoginRequestDto.getPassword(), memberLoginRequestDto.getEmail());
+        memberService.validatePassword(password, email);
+
+        // 토콘 생성 및 저장
+        this.memberService.generateToken(email, response);
+        this.memberService.generateAndSaveRefreshToken(response);
 
         return ResponseEntity.ok("로그인 성공");
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<String> logout() {
-
+    public ResponseEntity<String> logout(HttpServletResponse response) {
+        this.memberService.logout(response);
         return ResponseEntity.ok("로그아웃 성공");
     }
 }

--- a/src/main/java/sns/pinocchio/presentation/member/MemberController.java
+++ b/src/main/java/sns/pinocchio/presentation/member/MemberController.java
@@ -1,7 +1,68 @@
 package sns.pinocchio.presentation.member;
 
-import org.springframework.stereotype.Controller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sns.pinocchio.application.member.MemberService;
 
-@Controller
+@RequestMapping("/member")
+@RequiredArgsConstructor
+@RestController
 public class MemberController {
+
+    private final MemberService memberService;
+
+    // 회원 정보 조회
+    @GetMapping("/{memberId}")
+    public ResponseEntity<String> getMemberInfo(@PathVariable Long memberId) {
+        return ResponseEntity.ok("회원 정보 조회 성공");
+    }
+
+    // 회원 정보 수정
+    @PutMapping("/{memberId}")
+    public ResponseEntity<String> updateMemberInfo(@PathVariable Long memberId) {
+        return ResponseEntity.ok("회원 정보 수정 성공");
+    }
+
+    // 임시 비밀번호 발송
+    @PostMapping("/{memberId}/password/reset")
+    public ResponseEntity<String> sendTemporaryPassword(@PathVariable Long memberId) {
+        return ResponseEntity.ok("임시 비밀번호 발송 성공");
+    }
+
+    // 비밀번호 변경
+    @PutMapping("/{memberId}/password")
+    public ResponseEntity<String> changePassword(@PathVariable Long memberId) {
+        return ResponseEntity.ok("비밀번호 변경 성공");
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<String> deleteMember(@PathVariable Long memberId) {
+        return ResponseEntity.ok("회원 탈퇴 성공");
+    }
+
+    // 계정 신고
+    @PostMapping("/report")
+    public ResponseEntity<String> reportMember(@RequestParam Long targetMemberId) {
+        return ResponseEntity.ok("계정 신고 성공");
+    }
+
+    // 계정 차단
+    @PostMapping("/block")
+    public ResponseEntity<String> blockMember(@RequestParam Long targetMemberId) {
+        return ResponseEntity.ok("계정 차단 성공");
+    }
+
+    // 계정 차단 해제
+    @PostMapping("/unblock")
+    public ResponseEntity<String> unblockMember(@RequestParam Long targetMemberId) {
+        return ResponseEntity.ok("계정 차단 해제 성공");
+    }
+
+    // 차단한 유저 조회
+    @GetMapping("/block")
+    public ResponseEntity<String> getBlockedMembers(@RequestParam Long memberId) {
+        return ResponseEntity.ok("차단한 유저 조회 성공");
+    }
 }

--- a/src/main/java/sns/pinocchio/presentation/member/MemberController.java
+++ b/src/main/java/sns/pinocchio/presentation/member/MemberController.java
@@ -1,0 +1,7 @@
+package sns.pinocchio.presentation.member;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class MemberController {
+}

--- a/src/main/java/sns/pinocchio/presentation/member/exception/MemberErrorCode.java
+++ b/src/main/java/sns/pinocchio/presentation/member/exception/MemberErrorCode.java
@@ -11,6 +11,7 @@ public enum MemberErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER_401", "비밀번호가 올바르지 않습니다."),
     ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "USER_403", "정지된 계정입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "USER_401", "로그인이 필요합니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404", "이메일이 존재하지 않습니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "USER_409", "이미 사용 중인 이메일입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sns/pinocchio/presentation/member/exception/MemberErrorCode.java
+++ b/src/main/java/sns/pinocchio/presentation/member/exception/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package sns.pinocchio.presentation.member.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum MemberErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404", "존재하지 않는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER_401", "비밀번호가 올바르지 않습니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "USER_403", "정지된 계정입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "USER_401", "로그인이 필요합니다."),
+    EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "USER_409", "이미 사용 중인 이메일입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/sns/pinocchio/presentation/member/exception/MemberException.java
+++ b/src/main/java/sns/pinocchio/presentation/member/exception/MemberException.java
@@ -1,0 +1,21 @@
+package sns.pinocchio.presentation.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberException extends RuntimeException {
+
+    private final MemberErrorCode memberErrorCode;
+
+    public MemberException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return memberErrorCode.getHttpStatus();
+    }
+
+    public String getCode() {
+        return memberErrorCode.getCode();
+    }
+}

--- a/src/main/java/sns/pinocchio/presentation/member/memberDto/MemberRequestDto.java
+++ b/src/main/java/sns/pinocchio/presentation/member/memberDto/MemberRequestDto.java
@@ -1,0 +1,31 @@
+package sns.pinocchio.presentation.member.memberDto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberRequestDto {
+
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    private String name;
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하로 입력해주세요.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    private String password;
+}

--- a/src/test/java/sns/pinocchio/domain/auth/AuthControllerTest.java
+++ b/src/test/java/sns/pinocchio/domain/auth/AuthControllerTest.java
@@ -1,0 +1,126 @@
+package sns.pinocchio.domain.auth;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import sns.pinocchio.application.member.MemberService;
+import sns.pinocchio.application.member.memberDto.MemberRequestDto;
+import sns.pinocchio.infrastructure.member.MemberRepository;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    public ResultActions loginAndGetResponse() throws Exception {
+        String loginRequestJson = """
+            {
+                "email" : "example@naver.com",
+                "password": "memberPassword123!"
+            }
+        """.trim();
+
+        return mockMvc.perform(
+                post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginRequestJson)
+        );
+    }
+
+    @BeforeEach
+    public void init() {
+        memberRepository.deleteAll();
+        MemberRequestDto member = new MemberRequestDto("member", "example@naver.com", "nick", "memberPassword123!");
+        memberService.createMember(member);
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    public void signupTest() throws Exception {
+        String signupRequestJson = """
+            {
+                "name" : "member",
+                "email" : "example1@naver.com",
+                "nickname" : "nickname",
+                "password": "memberPassword123!"
+            }
+        """.trim();
+
+        ResultActions signupResponse =  mockMvc.perform(
+                post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(signupRequestJson)
+        );
+
+        boolean result = memberRepository.existsByEmail("example1@naver.com");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("로그인 테스트")
+    public void loginSuccessTest() throws Exception {
+        ResultActions loginResponse = loginAndGetResponse();
+
+        // 응답 상태와 쿠키 검증
+        loginResponse
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("accessToken"))
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("accessToken", true))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("accessToken", true))
+                .andExpect(cookie().secure("refreshToken", true));
+    }
+
+    @Test
+    @DisplayName("로그아웃 테스트")
+    public void logoutSuccessTest() throws Exception {
+        // 로그인 후 응답 받기
+        ResultActions loginResponse = loginAndGetResponse();
+
+        // 로그인 후 쿠키가 존재하고, HttpOnly, Secure 설정이 잘 되어있는지 확인
+        String accessToken = loginResponse.andReturn().getResponse().getCookie("accessToken").getValue();
+        String refreshToken = loginResponse.andReturn().getResponse().getCookie("refreshToken").getValue();
+
+        // 쿠키가 null이 아니어야 함을 검증
+        assertNotNull(accessToken);
+        assertNotNull(refreshToken);
+
+        // 로그아웃 요청
+        ResultActions logoutResponse = mockMvc.perform(post("/api/auth/logout") // 로그아웃 경로를 확인해주세요.
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .cookie(new Cookie("refreshToken", refreshToken)));
+
+        logoutResponse
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("accessToken", ""))
+                .andExpect(cookie().value("refreshToken", ""));
+    }
+}

--- a/src/test/java/sns/pinocchio/domain/auth/AuthServiceTest.java
+++ b/src/test/java/sns/pinocchio/domain/auth/AuthServiceTest.java
@@ -1,0 +1,80 @@
+package sns.pinocchio.domain.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import sns.pinocchio.application.member.MemberService;
+import sns.pinocchio.application.member.memberDto.MemberRequestDto;
+import sns.pinocchio.infrastructure.member.MemberRepository;
+import sns.pinocchio.presentation.member.exception.MemberException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+public class AuthServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    public void init() {
+        MemberRequestDto member = new MemberRequestDto("member", "example@naver.com", "nick", "memberPassword123!");
+        memberService.createMember(member);
+    }
+
+    @Test
+    @DisplayName("계정 생성 테스트")
+    public void createMemberTest() {
+        boolean result = memberRepository.existsByEmail("example@naver.com");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 검증 성공 테스트")
+    public void validateEmail() {
+        assertThatCode(() -> memberService.validateEmail("example@naver.com"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 검증 실패 테스트")
+    public void validateEmail_Failure() {
+        assertThatThrownBy(() -> memberService.validateEmail("notfound@naver.com"))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining("이메일이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("패스워드 검증 성공 테스트")
+    public void validatePassword_Success() {
+        assertThatCode(() -> memberService.validatePassword("memberPassword123!", "example@naver.com"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("패스워드 검증 실패 테스트")
+    public void validatePassword_Failure() {
+        assertThatThrownBy(() -> memberService.validatePassword("notFoundPassword123!", "example@naver.com"))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining("비밀번호가 올바르지 않습니다.");
+    }
+}


### PR DESCRIPTION
## 🪐 작업 내용 (구현한 내용)
- member 도메인
- 회원가입 API, 로그인 API, 로그아웃 API
- 예외처리 핸들러
- 쿠키 저장
- JWT토큰, 리프레시토큰 인증 방식
- 리프레시토큰 Redis 저장 
- MemberFilter 구현 (토큰 검증)
- auth 서비스 메서드 테스트
- auth 통합 테스트

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요? 넵
- [ ] 테스트 코드를 통과했나요? 넵
- [ ] merge할 브랜치의 위치를 확인했나요? 넵
- [ ] Label을 지정했나요? 넹
